### PR TITLE
[Fix] TypeError: Cannot interpolate with all NaNs

### DIFF
--- a/tracklets/python/bag_to_kitti.py
+++ b/tracklets/python/bag_to_kitti.py
@@ -297,16 +297,16 @@ def main():
         if include_images:
             camera_df.to_csv(os.path.join(dataset_outdir, 'capture_vehicle_camera.csv'), index=False)
 
-        cap_rear_gps_df = pd.DataFrame(data=cap_rear_gps_dict, columns=gps_cols)
+        cap_rear_gps_df = pd.DataFrame(data=cap_rear_gps_dict, columns=gps_cols).astype(float)
         cap_rear_gps_df.to_csv(os.path.join(dataset_outdir, 'capture_vehicle_rear_gps.csv'), index=False)
 
-        cap_front_gps_df = pd.DataFrame(data=cap_front_gps_dict, columns=gps_cols)
+        cap_front_gps_df = pd.DataFrame(data=cap_front_gps_dict, columns=gps_cols).astype(float)
         cap_front_gps_df.to_csv(os.path.join(dataset_outdir, 'capture_vehicle_front_gps.csv'), index=False)
 
-        cap_rear_rtk_df = pd.DataFrame(data=cap_rear_rtk_dict, columns=rtk_cols)
+        cap_rear_rtk_df = pd.DataFrame(data=cap_rear_rtk_dict, columns=rtk_cols).astype(float)
         cap_rear_rtk_df.to_csv(os.path.join(dataset_outdir, 'capture_vehicle_rear_rtk.csv'), index=False)
 
-        cap_front_rtk_df = pd.DataFrame(data=cap_front_rtk_dict, columns=rtk_cols)
+        cap_front_rtk_df = pd.DataFrame(data=cap_front_rtk_dict, columns=rtk_cols).astype(float)
         cap_front_rtk_df.to_csv(os.path.join(dataset_outdir, 'capture_vehicle_front_rtk.csv'), index=False)
 
         obs_rtk_df_dict = {}
@@ -322,7 +322,7 @@ def main():
             camera_df.set_index(['timestamp'], inplace=True)
             camera_df.index.rename('index', inplace=True)
 
-            camera_index_df = pd.DataFrame(index=camera_df.index)
+            camera_index_df = pd.DataFrame(index=camera_df.index).astype(float)
 
             cap_rear_gps_interp = interpolate_to_camera(camera_index_df, cap_rear_gps_df, filter_cols=gps_cols)
             cap_rear_gps_interp.to_csv(


### PR DESCRIPTION
#1 Issue reproduced under below environment:

ProductName:	Mac OS X
ProductVersion:	10.11.6

Running in docker built with provided DockerFile and build/execution scripts on [dataset2](http://academictorrents.com/details/18d7f6be647eb6d581f5ff61819a11b9c21769c7)

Camera/GPS/rtk dataFrames are converted to object types which produces below error

TypeError: Cannot interpolate with all NaNs

Hence, coerces dtype conversion to float. 

References:

[Issues:15657assignment should coerce dtype](https://github.com/pandas-dev/pandas/issues/15657)

[pandas-interpolate-returning-nans](http://stackoverflow.com/questions/24316481/pandas-interpolate-returning-nans)