### PR TITLE
[Update] Capture vehicle front/rear gps/rtk topic prefix

### DIFF
--- a/tracklets/python/bag_topic_def.py
+++ b/tracklets/python/bag_topic_def.py
@@ -7,9 +7,9 @@ CAMERA_TOPICS = [SINGLE_CAMERA_TOPIC]
 OLD_GPS_TOPIC = "/gps/fix"
 OLD_RTK_TOPIC = "/gps/rtkfix"
 
-CAP_REAR_GPS_TOPIC = "/capture_vehicle/rear/gps/fix"
-CAP_REAR_RTK_TOPIC = "/capture_vehicle/rear/gps/rtkfix"
-CAP_FRONT_GPS_TOPIC = "/capture_vehicle/front/gps/fix"
-CAP_FRONT_RTK_TOPIC = "/capture_vehicle/front/gps/rtkfix"
+CAP_REAR_GPS_TOPIC = "/objects/capture_vehicle/rear/gps/fix"
+CAP_REAR_RTK_TOPIC = "/objects/capture_vehicle/rear/gps/rtkfix"
+CAP_FRONT_GPS_TOPIC = "/objects/capture_vehicle/front/gps/fix"
+CAP_FRONT_RTK_TOPIC = "/objects/capture_vehicle/front/gps/rtkfix"
 
 OBJECTS_TOPIC_ROOT = "/objects"


### PR DESCRIPTION
#1 Issues 

@rwightman Thanks for the hint. Applying this fix generates capture_vehicle_front/rear_gps/rtk non-empty tables entries that match raw ROS message and data length. 